### PR TITLE
Make compatible with ArangoDB client 3.2+

### DIFF
--- a/Connection/Factory.php
+++ b/Connection/Factory.php
@@ -1,9 +1,9 @@
 <?php
 namespace Mop\ArangoDbBundle\Connection;
 
+use ArangoDBClient\Connection;
+use ArangoDBClient\ConnectionOptions;
 use Mop\ArangoDbBundle\LoggerInterface;
-use triagens\ArangoDb\ConnectionOptions;
-use triagens\ArangoDb\Connection;
 
 class Factory
 {

--- a/FOSUser/Model/UserManager.php
+++ b/FOSUser/Model/UserManager.php
@@ -1,15 +1,15 @@
 <?php
 namespace Mop\ArangoDbBundle\FOSUser\Model;
 
-use FOS\UserBundle\Model\UserManager as BaseUserManager;
+use ArangoDBClient\Connection;
+use ArangoDBClient\Document;
+use ArangoDBClient\DocumentHandler;
 use FOS\UserBundle\Model\UserInterface;
-use Symfony\Component\Validator\Constraint;
-use triagens\ArangoDb\Connection;
-use triagens\ArangoDb\DocumentHandler;
-use triagens\ArangoDb\Document;
+use FOS\UserBundle\Model\UserManager as BaseUserManager;
 use FOS\UserBundle\Util\CanonicalizerInterface;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Mop\ArangoDbBundle\FOSUser\User;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Validator\Constraint;
 
 class UserManager extends BaseUserManager
 {
@@ -72,7 +72,7 @@ class UserManager extends BaseUserManager
     {
         return $this->class;
     }
-    
+
     function reloadUser(UserInterface $user)
     {
         $document = $this->documentHandler->get($this->collection, $user->getId());
@@ -83,12 +83,12 @@ class UserManager extends BaseUserManager
     {
         $this->updateCanonicalFields($user);
         $this->updatePassword($user);
-        
+
         $id = $user->getId();
         $data = $user->toArray();
 
         $document = new Document;
-        
+
         foreach ($data as $k => $v) {
             if (isset($v)) {
                 if (is_object($v)) {
@@ -102,7 +102,7 @@ class UserManager extends BaseUserManager
                 }
             }
         }
-        
+
         if ($id) {
             $this->documentHandler->updateById($this->collection, $id, $document);
         } else {
@@ -110,17 +110,17 @@ class UserManager extends BaseUserManager
             $user->setId($id);
         }
     }
-    
+
     function validateUnique(UserInterface $value, Constraint $constraint)
     {
         $this->updateCanonicalFields($value);
         $fields = array_map('trim', explode(',', $constraint->property));
-        
+
         $criteria = array();
         foreach ($fields as $field) {
             $criteria[$field] = call_user_func_array(array($value, 'get'.ucfirst($field)), array());
         }
-        
+
         $users = $this->findUsersBy($criteria);
         if (count($users) == 0) {
             return true;

--- a/Resources/views/DataCollector/arangodb.html.twig
+++ b/Resources/views/DataCollector/arangodb.html.twig
@@ -12,7 +12,7 @@
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Request time</b>
-            <span>{{ '%0.2f'|format(collector.totaltime) }} ms</span>
+            <span>{{ '%0.2f'|format(collector.totaltime * 1000) }} ms</span>
         </div>
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
@@ -24,7 +24,7 @@
     <strong>ArangoDb</strong>
     <span class="count">
         <span>{{ collector.interactionscount }}</span>
-        <span>{{ '%0.0f'|format(collector.totaltime) }} ms</span>
+        <span>{{ '%0.0f'|format(collector.totaltime * 1000) }} ms</span>
     </span>
 </span>
 {% endblock %}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "target-dir": "Mop/ArangoDbBundle",
     "require": {
-        "triagens/ArangoDb": ">=2.0.0",
+        "triagens/ArangoDb": ">=3.2.0",
         "symfony/framework-bundle": ">=2.1.0"
     }
 }


### PR DESCRIPTION
Starting with version 3.2, the AgangoDB client uses a different top-level namespace: `ArangoDBClient` instead of `triagens/ArangoDB`. This PR makes the bundle compatible with these versions.